### PR TITLE
Make mandoc(1) happy

### DIFF
--- a/man/man5/configure.acr.5
+++ b/man/man5/configure.acr.5
@@ -33,14 +33,13 @@ generation of .acr files with SUBDIRS and SUBST_FILES
 .El
 .\"
 .Sh SYNTAX
-.Bl -tag -width indent
 The configure.acr file is a word-based configuration file for ACR.
 .Pp
 This means that each word must be separated with space, tab or new-lines.
 The ';' separator to terminate strings must be also a separated word.
 .Pp
-.Bl -tag -width indent
 Each word is called "keyword", there are these types:
+.Bl -tag -width indent
 .It Miscelaneous-Keys:
 { } ;
 .It Command:
@@ -210,8 +209,8 @@ Checks the existence of the target user or group on the system.
 .El
 .\"
 .Sh DEFINITIONS
-.Bl -tag -width indent
 Sets are processed at the beggining of the configure script.
+.Bl -tag -width indent
 .It = varname value\ ;
 Sets the value of varname to value.
 .It += varname value\ ;


### PR DESCRIPTION
mandoc -Tlint <filename> shows errors. This patch fixes them.
