### PR TITLE
Don't use /dev/stderr

### DIFF
--- a/doc/developers/string-mode
+++ b/doc/developers/string-mode
@@ -20,7 +20,7 @@ case "${MODE}" in
 	wait_string_mode
 
 	# do whatever i want with the string
-	echo "My string is: ${STRING}" >/dev/stderr
+	echo "My string is: ${STRING}" >&2
 
 	leave_string_mode
 ;;

--- a/src/acr
+++ b/src/acr
@@ -93,7 +93,7 @@ while [ $# -gt 0 ]; do
 		break;
 		;;
 	"-D"|"--dist")
-		echo "[1/4] Parsing configure.acr." >/dev/stderr
+		echo "[1/4] Parsing configure.acr." >&2
 		PBAR=1
 		MAKEDIST=1
 		NOPE=1
@@ -140,7 +140,7 @@ while [ $# -gt 0 ]; do
 done
 
 #if [ "`echo ${ACRFILE}|cut -c 1`" = "-" ]; then
-#	echo "error: unknown flag '${ACRFILE}'." > /dev/stderr
+#	echo "error: unknown flag '${ACRFILE}'." >&2
 #	exit 1
 #fi
 
@@ -151,7 +151,7 @@ if [ "${RECOVER}" = 1 ]; then
 fi
 
 if [ ! -f "${ACRFILE}" ]; then
-	echo "error: file ${ACRFILE} not found" > /dev/stderr
+	echo "error: file ${ACRFILE} not found" >&2
 	exit 1
 fi
 

--- a/src/acr-cat
+++ b/src/acr-cat
@@ -47,18 +47,18 @@ if [ -z "$1" ]; then
 fi
 
 if [ ! -f "$1" ]; then
-	echo "error: target file '$1' does not exist." > /dev/stderr
+	echo "error: target file '$1' does not exist." >&2
 	exit 1
 fi
 
 if [ ! -x "$1" ]; then
-	echo "error: target file '$1' is not executable." > /dev/stderr
+	echo "error: target file '$1' is not executable." >&2
 	exit 1
 fi
 
 VERSION="`./${1} --version 2>/dev/null`"
 if [ -z "`echo ${VERSION} | grep ACR`" ]; then
-	echo "error: this is not an acr generated configure script." > /dev/stderr
+	echo "error: this is not an acr generated configure script." >&2
 	exit 1
 fi
 

--- a/src/acr-sh
+++ b/src/acr-sh
@@ -1066,7 +1066,7 @@ pcgen() {
 	PCNAME=\"${S}{1}\" ; shift
 	REQUIRES=\"${S}@\"
 
-	echo \"generating ${S}{PCFILE}\" > /dev/stderr
+	echo \"generating ${S}{PCFILE}\" >&2
 	echo \"prefix=${S}{PREFIX}\" > ${S}{PCFILE}
 	echo \"exec_prefix=\\${S}{prefix}\" >> ${S}{PCFILE}
 	echo \"libdir=${S}{PKGCFG_LIBDIR}\" >> ${S}{PCFILE}

--- a/src/amr
+++ b/src/amr
@@ -114,7 +114,7 @@ check_cidep() {
 		[ "$A" = "$FILE" ] && return
 	done
 
-	echo "CInclude ${FILE} not found" > /dev/stderr
+	echo "CInclude ${FILE} not found" >&2
 	exit 1
 }
 
@@ -124,7 +124,7 @@ check_cdep() {
 		[ "$A" = "$FILE" ] && return
 	done
 
-	echo "CSource ${FILE} not found" > /dev/stderr
+	echo "CSource ${FILE} not found" >&2
 	exit 1
 }
 
@@ -212,7 +212,7 @@ fi
 
 parse_configure_amr() {
 FILE=$1
-echo "Parsing ${FILE}..." >/dev/stderr
+echo "Parsing ${FILE}..." >&2
 CONFIGURE_AMR="`cat ${FILE} 2>/dev/null`"
 for A in $CONFIGURE_AMR ; do
 	# TODO: Support for oneline commands and /* */
@@ -268,7 +268,7 @@ for A in $CONFIGURE_AMR ; do
 			eval "${CDEPS_VAR}=\"\$${CDEPS_VAR} ${A}\""
 			;;
 		*|0)
-			echo "Invalid keyword '$A'" > /dev/stderr
+			echo "Invalid keyword '$A'" >&2
 			exit 1
 			;;
 		esac


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

`/dev/stderr` is non-portable. The generated `configure` script fails with permission errors (cannot create /dev/stderr)